### PR TITLE
Wind Grabber: Only download newer datasets, use temporary directory inside python script.

### DIFF
--- a/apps/get_wind_data.py
+++ b/apps/get_wind_data.py
@@ -355,16 +355,6 @@ def wind_dict_to_cusf(data, output_dir='./gfs/'):
     return (_output_filename, output_text)
 
 
-# Copy a directory over another existing directory ( https://stackoverflow.com/a/12514470 )
-def copytree(src, dst, symlinks=False, ignore=None):
-    for item in os.listdir(src):
-        s = os.path.join(src, item)
-        d = os.path.join(dst, item)
-        if os.path.isdir(s):
-            shutil.copytree(s, d, symlinks, ignore)
-        else:
-            shutil.copy2(s, d)
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--age', type=int, default=0, help="Age of the model to grab, in blocks of 6 hours.")
@@ -441,6 +431,7 @@ if __name__ == '__main__':
         # Now process the 
         logging.info("Processing GRIB file...")
         _wind = parse_grib_to_dict(os.path.join(_temp_dir, 'temp.grib'))
+        remove(os.path.join(_temp_dir, 'temp.grib'))
 
         if _wind is not None:
             (_filename, _text) = wind_dict_to_cusf(_wind, output_dir=_temp_dir)
@@ -448,11 +439,12 @@ if __name__ == '__main__':
         else:
             logging.error("Error processing GRIB file.")
 
-    # Move all files from temporary directory to output directory
-    copytree(_temp_dir, args.output_dir)
+    # Remove output directory if it already exists
+    if os.path.exists(args.output_dir):
+        shutil.rmtree(args.output_dir)
 
-    # Clean up temporary directory
-    shutil.rmtree(_temp_dir)
+    # Move temporary directory to output directory
+    shutil.move(_temp_dir, args.output_dir)
 
     logging.info("Finished!")
 

--- a/apps/get_wind_data.py
+++ b/apps/get_wind_data.py
@@ -8,6 +8,9 @@
 #
 import sys
 import os.path
+from os import remove
+import shutil
+from tempfile import mkdtemp
 import traceback
 import requests
 import argparse
@@ -352,6 +355,15 @@ def wind_dict_to_cusf(data, output_dir='./gfs/'):
     return (_output_filename, output_text)
 
 
+# Copy a directory over another existing directory ( https://stackoverflow.com/a/12514470 )
+def copytree(src, dst, symlinks=False, ignore=None):
+    for item in os.listdir(src):
+        s = os.path.join(src, item)
+        d = os.path.join(dst, item)
+        if os.path.isdir(s):
+            shutil.copytree(s, d, symlinks, ignore)
+        else:
+            shutil.copy2(s, d)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -380,8 +392,24 @@ if __name__ == '__main__':
     if _model_dt == None:
         sys.exit(1)
 
+    # Check for existing dataset
+    if os.path.exists(os.path.join(args.output_dir, "dataset.txt")):
+        with open(os.path.join(args.output_dir, "dataset.txt"), 'r') as f:
+            f_data = f.read().replace('\n', '')
+        logging.info("Found existing dataset %s", f_data)
+        _existing_model_dt = datetime.datetime.strptime(f_data, "%Y%m%d%Hz")
+        if(_existing_model_dt >= _model_dt):
+            logging.info("No new data available")
+            sys.exit(0)
+        else:
+            logging.info("Downloading newer dataset %s" % _model_dt.strftime("%Y%m%d%Hz"))
+
+    # Create temporary directory for download
+    _temp_dir = mkdtemp()
+    logging.info("Created temporary directory %s" % _temp_dir)
+
     # Write model name into dataset.txt
-    f = open(os.path.join(args.output_dir, "dataset.txt"), 'w')
+    f = open(os.path.join(_temp_dir, "dataset.txt"), 'w')
     f.write("%s" % _model_dt.strftime("%Y%m%d%Hz"))
     f.close()
 
@@ -402,7 +430,7 @@ if __name__ == '__main__':
             londelta=args.londelta
             )
 
-        success = download_grib(url, params, filename='temp.grib')
+        success = download_grib(url, params, filename=os.path.join(_temp_dir, 'temp.grib'))
 
         if success:
             logging.info("Downloaded data for T+%03d" % forecast_time)
@@ -412,13 +440,19 @@ if __name__ == '__main__':
 
         # Now process the 
         logging.info("Processing GRIB file...")
-        _wind = parse_grib_to_dict('temp.grib')
+        _wind = parse_grib_to_dict(os.path.join(_temp_dir, 'temp.grib'))
 
         if _wind is not None:
-            (_filename, _text) = wind_dict_to_cusf(_wind, output_dir=args.output_dir)
+            (_filename, _text) = wind_dict_to_cusf(_wind, output_dir=_temp_dir)
             logging.info("GFS data written to: %s" % _filename)
         else:
             logging.error("Error processing GRIB file.")
+
+    # Move all files from temporary directory to output directory
+    copytree(_temp_dir, args.output_dir)
+
+    # Clean up temporary directory
+    shutil.rmtree(_temp_dir)
 
     logging.info("Finished!")
 

--- a/apps/get_wind_data.py
+++ b/apps/get_wind_data.py
@@ -354,6 +354,27 @@ def wind_dict_to_cusf(data, output_dir='./gfs/'):
 
     return (_output_filename, output_text)
 
+# Copy a directory over another existing directory ( https://stackoverflow.com/a/12514470 )
+def copytree(src, dst, symlinks=False, ignore=None):
+    for item in os.listdir(src):
+        s = os.path.join(src, item)
+        d = os.path.join(dst, item)
+        if os.path.isdir(s):
+            shutil.copytree(s, d, symlinks, ignore)
+        else:
+            shutil.copy2(s, d)
+
+# Remove directory contents ( https://stackoverflow.com/a/185941 )
+def remove_dir_contents(_dir):
+    for file in os.listdir(_dir):
+        file_path = os.path.join(_dir, file)
+        try:
+            if os.path.isfile(file_path):
+                os.unlink(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+        except Exception as e:
+            print(e)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -439,12 +460,17 @@ if __name__ == '__main__':
         else:
             logging.error("Error processing GRIB file.")
 
-    # Remove output directory if it already exists
+    # Clean out output directory if it already exists, create if it does not
     if os.path.exists(args.output_dir):
-        shutil.rmtree(args.output_dir)
+        remove_dir_contents(args.output_dir)
+    else:
+        os.mkdir(args.output_dir)
 
-    # Move temporary directory to output directory
-    shutil.move(_temp_dir, args.output_dir)
+    # Copy temporary directory into output directory
+    copytree(_temp_dir, args.output_dir)
+
+    # Clean up temporary directory
+    shutil.rmtree(_temp_dir)
 
     logging.info("Finished!")
 

--- a/apps/wind_grabber.sh
+++ b/apps/wind_grabber.sh
@@ -5,19 +5,6 @@
 # An example of how get_wind_data.py could be run as a cron-job, to keep a directory of wind data up to date.
 #
 
-# Make Temporary GFS data store if it doesn't already exist
-mkdir gfs_temp
-
-# Clear out directory
-rm gfs_temp/*.dat
-
 # Run get_wind_data.py
 # Update arguments as required.
-python get_wind_data.py --lat=-33 --lon=139 --latdelta=10 --londelta=10 -f 24 -m 0p25_1hr -o gfs_temp
-
-# Clear out data in gfs directory, and copy new data in.
-rm gfs/*.dat
-rm gfs/dataset.txt
-cp gfs_temp/*.dat gfs/
-cp gfs_temp/dataset.txt gfs/
-
+python get_wind_data.py --lat=-33 --lon=139 --latdelta=10 --londelta=10 -f 24 -m 0p25_1hr -o gfs/


### PR DESCRIPTION
Main motivation for this was to recognise when we had the latest available dataset and exit normally without downloading it again.

This required the python script to know about the real output directory, and so this change also creates the temporary directory inside the python script.

If the output directory exists then after downloading newer data, it is deleted and the temporary directory containing the newer data is moved into it's place. (ie. rm -r gfs/; mv <temp_dir> gfs/; )