### PR TITLE
Updates for FV3 Model

### DIFF
--- a/apps/get_wind_data.py
+++ b/apps/get_wind_data.py
@@ -287,7 +287,7 @@ def wind_dict_to_cusf(data, output_dir='./gfs/'):
             _pressures.append(_key)
 
     # Sort the list of pressures from highest to lowest
-    _pressures = np.flip(np.sort(_pressures),0)
+    _pressures = np.sort(_pressures)[::-1]
 
 
     # Build up the output file, section by section.


### PR DESCRIPTION
This PR updates get_wind_data.py to work with the new FV3 model updates. See here for more info: https://luckgrib.com/models/gfs_nextgen/

The main differences are:

- The model path now has a / between the date and the hour.
- There is a new 0.4mb pressure level available.

This PR will be merged on the 12th of June when the switchover to the new model occurs.